### PR TITLE
[Feature] Add support for exclusions list

### DIFF
--- a/SensioLabs/Security/SecurityChecker.php
+++ b/SensioLabs/Security/SecurityChecker.php
@@ -85,14 +85,14 @@ class SecurityChecker
      */
     private function getSecurityExclusions($configFile)
     {
-        try {
-            $config = json_decode(file_get_contents($configFile), true);
+        $config = json_decode(file_get_contents($configFile), true);
 
-            if ($config['exclusions'] && is_array($config['exclusions'])) {
-                return $config['exclusions'];
-            }
-        } catch (\Exception $e) {
+        if ($config === null) {
             throw new RuntimeException('Config file does not contain valid json.');
+        }
+
+        if ($config['exclusions'] && is_array($config['exclusions'])) {
+            return $config['exclusions'];
         }
 
         return [];


### PR DESCRIPTION
Reads a securityChecker.json config file from a project (same location as composer.lock) and excludes any exclusions listed there from the security checks. 

This will allow us to continue using the security checker while ignoring vulnerabilities that either do not affect us, or we are unable to currently fix (e.g. due to platform requirements)